### PR TITLE
FixUploadOtherFileFail

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -11,7 +11,7 @@ const (
 	DBConfigFile          = "conf/db.json"
 	CloudConfigFile       = "conf/cloud.yml"
 	CloudConfigDBName     = "cloud"
-	AliyunOSSCallbackBody = `"bucket":${bucket},"object":${object},"etag":${etag},"size":${size},"mimeType":${mimeType},"height":${imageInfo.height},"width":${imageInfo.width},"format":${imageInfo.format}`
+	AliyunOSSCallbackBody = `"bucket":${bucket},"object":${object},"etag":${etag},"size":${size},"mimeType":${mimeType}`
 	ReCodeLength          = 4
 	UserTokenLength       = 32
 	MYSQLTIMEZONE         = "Asia%2FShanghai"

--- a/item/upload.go
+++ b/item/upload.go
@@ -422,9 +422,6 @@ type FileInfo struct {
 	Etag     string `json:"etag"`
 	Size     int    `json:"size"`
 	MimeType string `json:"mimeType"`
-	Height   int    `json:"height"`
-	Width    int    `json:"width"`
-	Format   string `json:"format"`
 }
 
 type FinishedFiles struct {


### PR DESCRIPTION
修复：上传非图片文件错误
原因：阿里云 非图片文件 的上传回调JSON格式不规范
```json

{
.........,
"height":,
"width":,
"format":null
}
```
导致我方服务器解析错误。
解决办法：去除暂未利用的的图片信息（宽度，高度，具体格式）
